### PR TITLE
Fix database migration ENOENT in compiled binary

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -111,6 +111,30 @@ const targets = singleFlag
 
 await $`rm -rf dist`
 
+// Inline database migrations for compiled binary
+const migrationDir = path.join(dir, "migration")
+const migrationEntries = fs
+  .readdirSync(migrationDir, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => {
+    const sqlFile = path.join(migrationDir, e.name, "migration.sql")
+    if (!fs.existsSync(sqlFile)) return null
+    const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(e.name)
+    if (!match) return null
+    const timestamp = Date.UTC(
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      Number(match[4]),
+      Number(match[5]),
+      Number(match[6]),
+    )
+    return { sql: fs.readFileSync(sqlFile, "utf-8"), timestamp }
+  })
+  .filter(Boolean)
+  .sort((a, b) => a!.timestamp - b!.timestamp)
+console.log(`Inlined ${migrationEntries.length} database migrations`)
+
 // Build the app first
 console.log("building app...")
 await $`cd ../app && bun run build`
@@ -165,6 +189,7 @@ for (const item of targets) {
       NANOGPT_WORKER_PATH: workerPath,
       NANOGPT_CHANNEL: `'${Script.channel}'`,
       NANOGPT_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
+      NANOGPT_MIGRATIONS: JSON.stringify(migrationEntries),
     },
   })
 


### PR DESCRIPTION
## Summary

Fixes #52 — compiled binary fails with `ENOENT: no such file or directory, scandir '/$bunfs/migration'` on all platforms.

**Root cause:** `NANOGPT_MIGRATIONS` is not defined in the `Bun.build()` `define` block in `build.ts`. The runtime code in `db.ts` checks `typeof NANOGPT_MIGRATIONS !== "undefined"` and falls back to reading migration files from disk via `import.meta.dirname` — but in a compiled binary, that resolves to `/$bunfs/root/src/storage`, and the relative `../../migration` path points to `/$bunfs/migration` which doesn't exist in the virtual filesystem.

**Fix:** Read migration directories at build time and inline their SQL content via the `NANOGPT_MIGRATIONS` define constant that `db.ts` already checks for. The build-time code replicates the same timestamp parsing logic from `db.ts`'s `time()` function.

## Verified

Built locally with `bun run build --single --skip-install` (bun 1.3.9, linux x64). Fresh database test shows:

```
INFO  service=db count=3 mode=bundled applying migrations
```

All 3 migrations applied, `auth login` launches successfully.

## Changes

- `packages/opencode/script/build.ts`: Read migration SQL files at build time, add `NANOGPT_MIGRATIONS` to the `define` block